### PR TITLE
feat: :sparkles: notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
     "socket.io-client": "^4.8.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "expo-notifications": "~0.28.19",
+    "expo-device": "~6.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/services/user.ts
+++ b/services/user.ts
@@ -3,6 +3,11 @@ import { ImageType, User, UserAccount } from "@/types/types";
 import { UserContext } from "@/utils/Provider";
 import { parseUserContext } from "@/utils/utils";
 import { UploadResult, ref, uploadBytes } from "firebase/storage";
+import { Platform } from 'react-native';
+import * as Device from 'expo-device';
+import Constants from 'expo-constants';
+import * as Notifications from 'expo-notifications';
+import { getTokenFromStorage } from "./userLogin";
 
 export const modifyUserValue = async (idUser: string, field: 'name' | 'lastName' | 'username', value: string) => {
 
@@ -75,5 +80,102 @@ export const uploadProfilePicture = async (image: ImageType, idUser: string): Pr
         return snapshot
     } catch (error) {
         return
+    }
+}
+// no se envian notificaciones del lado del cliente por temas de seguridad
+// 
+// export async function sendPushNotification(expoPushToken: string) { 
+//     const message = {
+//         to: expoPushToken,
+//         sound: 'default',
+//         title: 'Original Title',
+//         body: 'And here is the body!',
+//         data: { someData: 'goes here' },
+//     };
+
+//     await fetch('https://exp.host/--/api/v2/push/send', {
+//         method: 'POST',
+//         headers: {
+//             Accept: 'application/json',
+//             'Accept-encoding': 'gzip, deflate',
+//             'Content-Type': 'application/json',
+//         },
+//         body: JSON.stringify(message),
+//     });
+// }
+
+function handleRegistrationError(errorMessage: string) {
+    alert(errorMessage);
+    throw new Error(errorMessage);
+}
+
+export const saveExpoPushToken = async (expoPushToken: string, idToken?: string) => {
+    const token = idToken ?? await getTokenFromStorage()
+    if (!token) return
+
+    const data = {
+        expo_push_token: expoPushToken
+    };
+    const options = {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify(data)
+    };
+
+    try {
+        const res = await fetch(`${API_URL}/users/notifications`, options);
+        if (res.status == 200) {
+            const response = await res.json()
+            return response
+        }
+        return await res.json()
+    } catch (error) {
+        console.log(error);
+
+        return false
+    }
+}
+
+export async function registerForPushNotificationsAsync() { // boilerplate, ignore this
+    if (Platform.OS === 'android') {
+        Notifications.setNotificationChannelAsync('default', {
+            name: 'default',
+            importance: Notifications.AndroidImportance.MAX,
+            vibrationPattern: [0, 250, 250, 250],
+            lightColor: '#FF231F7C',
+        });
+    }
+
+    if (Device.isDevice) {
+        const { status: existingStatus } = await Notifications.getPermissionsAsync();
+        let finalStatus = existingStatus;
+        if (existingStatus !== 'granted') {
+            const { status } = await Notifications.requestPermissionsAsync();
+            finalStatus = status;
+        }
+        if (finalStatus !== 'granted') {
+            handleRegistrationError('Permission not granted to get push token for push notification!');
+            return;
+        }
+        const projectId =
+            Constants?.expoConfig?.extra?.eas?.projectId ?? Constants?.easConfig?.projectId;
+        if (!projectId) {
+            handleRegistrationError('Project ID not found');
+        }
+        try {
+            const pushTokenString = (
+                await Notifications.getExpoPushTokenAsync({
+                    projectId,
+                })
+            ).data;
+            return pushTokenString;
+        } catch (e: unknown) {
+            handleRegistrationError(`${e}`);
+        }
+    } else {
+        handleRegistrationError('Must use physical device for push notifications');
     }
 }


### PR DESCRIPTION
register expoPushToken from device and send it to api/users/notifications to save it after login. Set notificationListener

works with https://github.com/Santiagof2/Backend-carpooling/pull/9

from doc: https://docs.expo.dev/push-notifications/push-notifications-setup/

### add secrets in expo.dev:
![image](https://github.com/user-attachments/assets/c4a853fb-4fa2-4204-ad8a-f02f1f5a2aff)

### configurate keystore
![image](https://github.com/user-attachments/assets/d5f01e16-7779-465c-8f08-1fb4318f7eb6)

### configurate FCM V1 secret:
![image](https://github.com/user-attachments/assets/b36f934c-9d17-4a09-bed7-b875d5d838be)

development build generated with eas build --profile development --platform android
demo running app, sending a notification in discord